### PR TITLE
Remove repayment terms checkbox and update to v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.4 (2025-10-07)
+- **Removed**: Isolated repayment terms checkbox from installment checkout section
+- **Improved**: Simplified checkout flow by removing redundant terms acceptance field
+
 ## 1.2.3 (2025-01-27)
 - **Fixed**: All email and admin interface strings now use Norwegian language
 - **Improved**: Consistent language between checkout frontend and email notifications

--- a/simplylearn-installments.php
+++ b/simplylearn-installments.php
@@ -3,7 +3,7 @@
  * Plugin Name: SimplyLearn Installments
  * Plugin URI:  https://simplylearn.com/
  * Description: Classic Checkout installments gateway with 6/12/24/36 plans, APR + monthly fee, min-total gating, and order meta storage. Optional forward to external provider.
- * Version: 1.2.3
+ * Version: 1.2.4
  * Author: SimplyLearn AS
  * Author URI: https://simplylearn.com/
  * Requires at least: 6.0
@@ -14,7 +14,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'SLI_VERSION', '1.2.3' );
+define( 'SLI_VERSION', '1.2.4' );
 define( 'SLI_PLUGIN_FILE', __FILE__ );
 define( 'SLI_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SLI_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
- Removed isolated repayment terms checkbox from installment checkout section
- Removed terms validation from validate_fields() method
- Removed terms_acc variable and installment_terms_accepted meta storage
- Removed terms acceptance display from admin order panel
- Updated plugin version to 1.2.4
- Updated CHANGELOG.md with version 1.2.4 entry