### PR TITLE
feat: Add customer verification on checkout page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1 (2025-10-15)
+- **Enhanced**: Wattn customer verification now triggers on checkout page load
+- **Improved**: Member status is refreshed when approaching checkout to ensure benefits are current
+- **Added**: Automatic verification check before payment methods are displayed
+- **Fixed**: Member benefits now accurately reflect real-time customer status at checkout
+
 ## 1.4.0 (2025-10-14)
 - **Changed**: Removed 5% APR interest calculation from installment payments
 - **Simplified**: Monthly payment calculation now uses simple division (principal / months + monthly fee)

--- a/includes/class-wattn-customer-verification.php
+++ b/includes/class-wattn-customer-verification.php
@@ -36,6 +36,9 @@ class Wattn_Customer_Verification {
         
         // Hook into profile update (optional - updates when user changes their info)
         add_action( 'profile_update', [ __CLASS__, 'on_profile_update' ], 10, 2 );
+        
+        // Hook into checkout page load to verify member status when benefits apply
+        add_action( 'woocommerce_before_checkout_form', [ __CLASS__, 'on_checkout_page' ], 5 );
     }
     
     /**
@@ -91,6 +94,17 @@ class Wattn_Customer_Verification {
             if ( $should_update ) {
                 self::update_customer_status( $user_id );
             }
+        }
+    }
+    
+    /**
+     * Handle checkout page load event
+     * Updates customer status when user visits checkout to ensure benefits are current
+     */
+    public static function on_checkout_page() {
+        if ( is_user_logged_in() ) {
+            $user_id = get_current_user_id();
+            self::update_customer_status( $user_id );
         }
     }
     

--- a/simplylearn-installments.php
+++ b/simplylearn-installments.php
@@ -3,7 +3,7 @@
  * Plugin Name: SimplyLearn Installments
  * Plugin URI:  https://simplylearn.com/
  * Description: Classic Checkout installments gateway with 6/12/24/36 plans, monthly fee (no interest), min-total gating, and order meta storage. Optional forward to external provider. Includes Wattn customer verification.
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: SimplyLearn AS
  * Author URI: https://simplylearn.com/
  * Requires at least: 6.0
@@ -14,7 +14,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'SLI_VERSION', '1.4.0' );
+define( 'SLI_VERSION', '1.4.1' );
 define( 'SLI_PLUGIN_FILE', __FILE__ );
 define( 'SLI_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SLI_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
- Add woocommerce_before_checkout_form hook to trigger verification
- Ensure member status is fresh before payment methods display
- Verify customer status when users approach checkout
- Update version to 1.4.1
- Update CHANGELOG with enhancement details